### PR TITLE
Support using GIT_SSH environment variable

### DIFF
--- a/src/Win32-OpenSSH.ps1
+++ b/src/Win32-OpenSSH.ps1
@@ -39,7 +39,12 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
         Start-Service "ssh-agent"
     }
 
-    if (!$env:GIT_SSH) {
+    if ($env:GIT_SSH) {
+        if (!$Quiet) {
+            Write-Host "GIT_SSH is set, not setting core.sshCommand in .gitconfig"
+        }
+    }
+    else {
         # Make sure git is configured to use OpenSSH-Win32
         $sshCommand = (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path).Replace("\", "/")
         $configuredSshCommand = git config --global core.sshCommand

--- a/src/Win32-OpenSSH.ps1
+++ b/src/Win32-OpenSSH.ps1
@@ -39,22 +39,24 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
         Start-Service "ssh-agent"
     }
 
-    # Make sure git is configured to use OpenSSH-Win32
-    $sshCommand = (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path).Replace("\", "/")
-    $configuredSshCommand = git config --global core.sshCommand
+    if (!$env:GIT_SSH) {
+        # Make sure git is configured to use OpenSSH-Win32
+        $sshCommand = (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path).Replace("\", "/")
+        $configuredSshCommand = git config --global core.sshCommand
 
-    if ($configuredSshCommand) {
-        # If it's already set to something else, warn the user.
-        if ($configuredSshCommand -ne $sshCommand) {
-            Write-Warning "core.sshCommand in your .gitconfig is set to $configuredSshCommand, but it should be set to $sshCommand."
+        if ($configuredSshCommand) {
+            # If it's already set to something else, warn the user.
+            if ($configuredSshCommand -ne $sshCommand) {
+                Write-Warning "core.sshCommand in your .gitconfig is set to $configuredSshCommand, but it should be set to $sshCommand."
+            }
         }
-    }
-    else {
-        if (!$Quiet) {
-            Write-Host "Setting core.sshCommand to $sshCommand in .gitconfig"
+        else {
+            if (!$Quiet) {
+                Write-Host "Setting core.sshCommand to $sshCommand in .gitconfig"
+            }
+            $sshCommand = "`"$sshCommand`""
+            git config --global core.sshCommand $sshCommand
         }
-        $sshCommand = "`"$sshCommand`""
-        git config --global core.sshCommand $sshCommand
     }
 
     Add-SshKey -Quiet:$Quiet

--- a/test/Ssh.Tests.ps1
+++ b/test/Ssh.Tests.ps1
@@ -161,6 +161,24 @@ Describe 'SSH Function Tests' {
                 "$args" -eq 'config --global core.sshCommand "C:/Windows/System32/OpenSSH/ssh.exe"'
             } -Scope It
         }
+
+        It "Doesn't set the sshCommand in .gitconfig if GIT_SSH env var is set" {
+            $env:GIT_SSH = 'C:/Program Files/OpenSSH-Win64/ssh.exe'
+            $service.Status = "Running"
+
+            Mock git { return "C:/Windows/System32/OpenSSH/ssh.exe" } -ParameterFilter {
+                "$args" -eq "config --global core.sshCommand"
+            }
+
+            $result = Start-NativeSshAgent -Quiet
+
+            Assert-MockCalled git -Times 0 -Exactly -ParameterFilter {
+                "$args" -eq 'config --global core.sshCommand "C:/Windows/System32/OpenSSH/ssh.exe"'
+            } -Scope It
+
+            Remove-Item env:\GIT_SSH
+        }
+
         It "Stops the service" {
             $service.Status = "Running"
             Mock Stop-Service { $service.Status = "Stopped" } -ParameterFilter { $Name -eq "ssh-agent" }


### PR DESCRIPTION
I use several development environments, including `msys2` and WSL. The default behavior of this project to always set `core.sshCommand` isn't necessarily what I want since using Win32-OpenSSH from `msys2` doesn't work.

In my POSH profile, I set `GIT_SSH` myself to Win32-OpenSSH and do not set it using `core.sshCommand` in the following manner, before running `Start-SshAgent`.

```
function Get-NativeSshAgent {
    # $IsWindows is defined in PS Core.
    if (($PSVersionTable.PSVersion.Major -lt 6) -or $IsWindows) {
        # The ssh.exe binary version must include "OpenSSH"
        # The windows ssh-agent service must exist
        $service = Get-Service ssh-agent -ErrorAction Ignore
        $executableMatches = Get-Command ssh.exe | ForEach-Object FileVersionInfo | Where-Object ProductVersion -match OpenSSH
        $valid = $service -and $executableMatches
        if ($valid) {
            return $service;
        }
    }
}

$nugetModule = Get-Module -Name NuGet
$isInteractiveDesktop = [bool]((Test-Path env:\SESSIONNAME) -And ($env:SESSIONNAME -eq 'Console') -Or (Test-Path env:\WT_SESSION))
$isNonInteractive = [bool]([Environment]::GetCommandLineArgs() -Like '*NonInteractive*')
if (($nugetModule -eq $null) -And ($isInteractiveDesktop -eq $true) -And ($isNonInteractive -eq $false))
{
    # https://github.com/dahlbyk/posh-git/wiki/Customizing-Your-PowerShell-Prompt
    Import-Module 'C:\Users\lbakken\development\dahlbyk\posh-sshell\posh-sshell.psd1'
    Import-Module 'C:\Users\lbakken\development\dahlbyk\posh-git\src\posh-git.psd1'
    $GitPromptSettings.WindowTitle = [psobject]{param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})$(if ($GitStatus) {"$($GitStatus.RepoName) [$($GitStatus.Branch)]"} else {Get-PromptPath})"}
    $env:TERM = 'xterm-256color'
    $env:LESS = 'FRSX'

    $service = Get-NativeSshAgent
    if ($service) {
        $serviceName = $service.DisplayName
        Write-Host "Using native ssh agent service: $serviceName"
        $ssh = (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path).Replace("\", "/")
        Write-Host "Setting GIT_SSH to $ssh"
        $env:GIT_SSH = $ssh
    }

    Start-SshAgent
}
```