### PR TITLE
Support for single-quoted core.sshCommand

### DIFF
--- a/posh-sshell.psd1
+++ b/posh-sshell.psd1
@@ -4,7 +4,7 @@
   RootModule = 'posh-sshell.psm1'
 
   # Version number of this module.
-  ModuleVersion = '0.4.0'
+  ModuleVersion = '0.3.2'
 
   # ID used to uniquely identify this module
   GUID = '2716974a-b8d1-440d-acdd-3e28d83e18d4'

--- a/src/Win32-OpenSSH.ps1
+++ b/src/Win32-OpenSSH.ps1
@@ -45,7 +45,7 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
 
     if ($configuredSshCommand) {
         # If it's already set to something else, warn the user.
-        if ($configuredSshCommand -ne $sshCommand) {
+        if (($configuredSshCommand  -replace '^''(.*)''$', '$1') -ne ($sshCommand -replace '^''(.*)''$', '$1')) {
             Write-Warning "core.sshCommand in your .gitconfig is set to $configuredSshCommand, but it should be set to $sshCommand."
         }
     }
@@ -53,7 +53,7 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
         if (!$Quiet) {
             Write-Host "Setting core.sshCommand to $sshCommand in .gitconfig"
         }
-        $sshCommand = "`"$sshCommand`""
+        $sshCommand = "`"'$sshCommand'`""
         git config --global core.sshCommand $sshCommand
     }
 


### PR DESCRIPTION
Changed so there's no warning when $sshCommand and $configuredSshCommand differs only in quoting.